### PR TITLE
Optionnal content deduplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,4 @@
 - added S3 optimization cache support
 - supports custom about page, favicon and CSS
 - supports scraping from any topic node
+- support basic deduplication of files upon request

--- a/kolibri2zim/entrypoint.py
+++ b/kolibri2zim/entrypoint.py
@@ -157,6 +157,16 @@ def main():
     )
 
     parser.add_argument(
+        "--dedup-html-files",
+        help="Deduplicates in-HTML5 App files by adding each only once and creating "
+        "redirects. Usefull for channel with duplicated files (assets) in app. "
+        "Caution: can break links if HTML5 app is not completely flat",
+        dest="dedup_html_files",
+        default=False,
+        action="store_true",
+    )
+
+    parser.add_argument(
         "--debug", help="Enable verbose output", action="store_true", default=False
     )
 

--- a/kolibri2zim/scraper.py
+++ b/kolibri2zim/scraper.py
@@ -3,7 +3,6 @@
 # vim: ai ts=4 sts=4 et sw=4 nu
 
 import io
-import queue
 import shutil
 import base64
 import zipfile
@@ -57,6 +56,7 @@ options = [
     "only_topics",
     "about",
     "css",
+    "dedup_html_files",
 ]
 
 
@@ -117,7 +117,8 @@ class Kolibri2Zim:
         self.nb_processes = go("processes")
         self.s3_url_with_credentials = go("s3_url_with_credentials")
         self.s3_storage = None
-        self.file_cache = dict()
+        self.dedup_html_files = go("dedup_html_files")
+        self.html_files_cache = []
 
         # debug/developer options
         self.keep_build_dir = go("keep_build_dir")
@@ -595,37 +596,36 @@ class Kolibri2Zim:
         ark_data = io.BytesIO()
         stream_file(url=ark_url, byte_stream=ark_data)
 
-        # loop over zip members and create an entry for each
+        # loop over zip members and create an entry (or redir. for each if using dedup)
         zip_ark = zipfile.ZipFile(ark_data)
         for ark_member in zip_ark.namelist():
-            filename_hash = hashlib.md5(ark_member.encode('utf-8')).hexdigest()
-            content = zip_ark.open(ark_member).read()
-            content_hash = hashlib.md5(content).hexdigest()
-            
-            if filename_hash not in self.file_cache:
-                self.file_cache[filename_hash] = content_hash
+            if not self.dedup_html_files:
                 with self.creator_lock:
                     self.creator.add_item_for(
-                        path=f"html5_files/{ark_member}",
+                        path=f"{node_id}/{ark_member}",
+                        content=zip_ark.open(ark_member).read(),
+                    )
+                continue
+
+            # calculate hash of file and add entry if not in zim already
+            content = zip_ark.open(ark_member).read()
+            content_hash = hashlib.md5(content).hexdigest()  # nosec
+
+            if content_hash not in self.html_files_cache:
+                self.html_files_cache.append(content_hash)
+                with self.creator_lock:
+                    self.creator.add_item_for(
+                        path=f"html5_files/{content_hash}",
                         content=content,
                     )
-                    self.creator.add_redirect(
-                        path=f"{node_id}/{ark_member}",
-                        target_path=f"html5_files/{ark_member}"
-                    )
-            else:
-                if self.file_cache[filename_hash] == content_hash:
-                    with self.creator_lock:
-                        self.creator.add_redirect(
-                            path=f"{node_id}/{ark_member}",
-                            target_path=f"html5_files/{ark_member}"
-                        )
-                else:
-                    with self.creator_lock:
-                        self.creator.add_item_for(
-                            path=f"{node_id}/{ark_member}",
-                            content=content,
-                        )
+
+            # add redirect to the unique sum-based entry for that file's path
+            with self.creator_lock:
+                self.creator.add_redirect(
+                    path=f"{node_id}/{ark_member}",
+                    target_path=f"html5_files/{content_hash}"
+                )
+
         logger.debug(f"Added HTML5 node #{node_id}")
 
     def run(self):


### PR DESCRIPTION
@imnitishng, Thank you for your PR and sorry for the delay in responding to it.

It's a good addition ; I've tested it on a Libretext channel and it saves 600MB!

Though, I don't think this can be enabled by default. The major issue with it is its potential to break links.

Let's say you have an HTML app structured this way:
- `index.html` (mandatory)
- `sub/folder/page.html`

This will create two entries inside `html5_files/` with random filenames. When accessing the `index.html` one, use will be redirected to the proper page but the link to `./sub/folder/page.html` will not be resolved as the base path will be different.

It would be possible to create the main entries with the full path so having something like `html5_files/sub/folder/page.html` but this would
- restrict duplicates to identical filenames (what you already did)
- have unpredictable paths and duplication as this will depend a lot on ordering and bring up confusion.

Finally, I saw no value in keeping that hash of the filename so I simplified it a bit and made it optional.
I think informed people knowing there won't be no link broken can use it. Having it an optional param gives us room to tweak its behavior to make it a bit more flexible in the future (most duplicates are probably JS ones stored in subfolders)

Please let me know what you think of it.